### PR TITLE
AuthAnnonymous: add SASL compliance

### DIFF
--- a/dbus_next/auth.py
+++ b/dbus_next/auth.py
@@ -94,6 +94,8 @@ class AuthAnnonymous(Authenticator):
     def _receive_line(self, line: str) -> str:
         response, args = _AuthResponse.parse(line)
 
+        if response == _AuthResponse.DATA:
+            return 'DATA'
         if response != _AuthResponse.OK:
             raise AuthError(f'authentication failed: {response.value}: {args}')
 


### PR DESCRIPTION
The dbus specification states that its authentication mechanism is a SASL profile.

Unless (empty) data is provided with the mechanism right away (i.e. `AUTH ANONYMOUS `),
SASL compliant authentication responds with a `DATA` message.
While some dbus implementations do not do this, the sd-bus does as of systemd >=v242-rc1 [0].

This fixes the response in a backward compatible way by sending back an empty `DATA` message.

[0] https://github.com/systemd/systemd/commit/2010873b4b49b223e0cc07d28205b09c693ef005